### PR TITLE
Simplify creating the 'textArray'

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,24 +23,25 @@
             // replaces extra spaces, and multiple line returns with single space and line return.
             // splits the data where it has open comment (/*) and stores the result into an array.             
 
-            textArray = data.replace(/ {2,}/g, ' ').replace(/\/\*/g, "splithere").split("splithere").noSpaces("").noSpaces(" ");
+            textArray = data.replace(/ {2,}/g, ' ').replace(/\*\//g, "").split(/\/\*/g).noSpaces("");
 
-            // trims extra spaces from end and start of each index of the array.
-
+//            // trims extra spaces from end and start of each index of the array.
+//
             textArray = $.map(textArray, $.trim);
-
-            // creats a loop and appends each index of the array to the assigned section in the html
-            // . All three divs are placed inside the section called (testscript). 
-            // I am using slice to remove the closing comment (*/). I tried different ways and got
-            // some errors. If the script.js has multiplication sign (*), the array will be splited where
-            // it runs to (*). 
+            
+//
+//            // creats a loop and appends each index of the array to the assigned section in the html
+//            // . All three divs are placed inside the section called (testscript). 
+//            // I am using slice to remove the closing comment (*/). I tried different ways and got
+//            // some errors. If the script.js has multiplication sign (*), the array will be splited where
+//            // it runs to (*). 
             for (var i = 0; i < textArray.length; i++) {
 
                 if (i % 2 == 0) {
                     //$(".testScript").append("<section class=\"container\">");
-                    $(".testScript").append("<div class=\"one\"><pre><b>Instruction: </b><br/><br/>" + textArray[i].slice(0, ((textArray[i].length) - 2)) + "</pre></div><br/>");
+                    $(".testScript").append("<div class=\"one\"><pre><b>Instruction: </b><br/><br/>" + textArray[i] + "</pre></div><br/>");
 
-                    $(".testScript").append("<div class=\"two\"><pre><b>Code:</b><br/><br/>" + textArray[i + 1].slice(0, ((textArray[i + 1].length) - 2)) + "</pre><br/></div><br/>");
+                    $(".testScript").append("<div class=\"two\"><pre><b>Code:</b><br/><br/>" + textArray[i + 1] + "</pre><br/></div><br/>");
 
                     $(".testScript").append("<div class=\"three\"><button onclick=\"next(" + (i + 1) + ")\" type=\"button\" class=\"theButton\">Console.Log</button><br/></div><br/><hr/>");
                     //$(".testScript").append("</section>");
@@ -58,7 +59,7 @@
 
         function next(step) {
 
-            eval(textArray[step].slice(0, ((textArray[step].length) - 2)));
+            eval(textArray[step]);
             console.log("     < End of step >");
             console.log("     < Try the next step... >");
 
@@ -66,7 +67,8 @@
 
         // The function will remove the given parameter, which in this case is extra spaces
         // inside the array. 
-        Array.prototype.noSpaces = function(deleteValue) {
+//        Array.prototype.noSpaces = function(deleteValue) {
+        Array.prototype.noSpaces = function (deleteValue) {
             for (var i = 0; i < this.length; i++) {
                 if (this[i] == deleteValue) {
                     this.splice(i, 1);


### PR DESCRIPTION
Split on comment opening tag '/*' instead of 'splithere' text.
Removed the comment ending '*/' while creating the array.
This allows us to simplify the statements that create the html, and simplifies next().
    ... removed (.length -2)